### PR TITLE
Feat/admin pending toggle

### DIFF
--- a/app/Livewire/CalendarWidget.php
+++ b/app/Livewire/CalendarWidget.php
@@ -489,9 +489,9 @@ class CalendarWidget extends FullCalendarWidget
     {
         $actions = [];
 
-        // Approve Action if record is pending and is AdminPanel
-        if ($this->isAdminPanel() && $this->record instanceof Schedule && $this->record->status === ScheduleStatus::Pending) {
-            $approveAction= Action::make('approve')
+        // Approve Action if record is pending and is AdminPanel ($record is only set after an event is clicked)
+        if ($this->isAdminPanel() && isset($this->record) && $this->record instanceof Schedule && $this->record->status === ScheduleStatus::Pending) {
+            $approveAction = Action::make('approve')
                 ->label('Finalize Room & Approve')
                 ->icon('heroicon-o-check-circle')
                 ->color('success')


### PR DESCRIPTION
This pull request enhances the `CalendarWidget` to improve the management and visibility of pending schedules, especially for admin users. The main changes introduce a toggle for showing valid pending schedules that are not blocked by approved events, update the event color scheme for pending schedules, and add an admin-only approve action for pending events.

**Admin panel enhancements:**

* Added a toggle button (`showValidPendingSchedules`) to the header actions, allowing admins to show or hide valid pending schedules that do not overlap with any approved schedules. [[1]](diffhunk://#diff-8238abed4b46b97ff2a2fccc770e10182a594f7e8cbc445e6a661acfa227a636R36-R37) [[2]](diffhunk://#diff-8238abed4b46b97ff2a2fccc770e10182a594f7e8cbc445e6a661acfa227a636R192-R200)
* Modified the schedule query logic in `fetchEvents` to include valid pending schedules when the toggle is active, ensuring only those not blocked by approved events are shown.

**UI improvements for pending schedules:**

* Updated the color scheme for pending schedules: background and border colors now use orange (`#ea580c`) to make pending events stand out more clearly in the calendar. [[1]](diffhunk://#diff-8238abed4b46b97ff2a2fccc770e10182a594f7e8cbc445e6a661acfa227a636R436-R437) [[2]](diffhunk://#diff-8238abed4b46b97ff2a2fccc770e10182a594f7e8cbc445e6a661acfa227a636L429-R458)

**Admin-only actions:**

* Added an "Approve" modal action for pending schedules in the admin panel, allowing admins to finalize and approve room bookings directly from the event modal.

closes #2